### PR TITLE
Update README.md

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -6,10 +6,25 @@
     - [dbpd toolbox](https://github.com/biomarkersParkinson/dbpd-toolbox): the main toolbox for data processing outputing scores indicating the progression of Parkinson's
 - Project documentation
     - [docs](https://github.com/biomarkersParkinson/docs): for general documentation.
+- Research domains
+    - Gait
+        - [general](https://github.com/biomarkersParkinson/gait): General codebase including exploratory notebooks
+        - [pdathome](https://github.com/biomarkersParkinson/pdathome_gait): PD@Home study (published code)
+        - [SSL](https://github.com/biomarkersParkinson/ssl_gait): Self-supervised learning
+        - [QC](https://github.com/biomarkersParkinson/arm-swing-features-and-qc): Quality control
+    - Tremor
+        - [train_test_evaluate](https://github.com/biomarkersParkinson/tremor2-training-validation-evaluation): X
+        - [rest_tremor_ppp](https://github.com/biomarkersParkinson/Rest-Tremor---PPP-library): X
+        - [weekly_aggregates](https://github.com/biomarkersParkinson/Tremor-Weekly-Aggregates): X
+        - [ppp_local_test](https://github.com/biomarkersParkinson/ppp-tremor-local-test): X
+        - [ppp](https://github.com/biomarkersParkinson/ppp-tremor): X
+        - [ppp_tremor_ppg](https://github.com/biomarkersParkinson/ppp-tremor-ppg): X
+        - [pdathome](https://github.com/biomarkersParkinson/pdathome-tremor): X
+        - [clinical_ppp](https://github.com/biomarkersParkinson/Exploratory-analysis-clinical-PPG): X
+    - Heart rate
+        - [PPG-analysis](https://github.com/biomarkersParkinson/PPG-analysis): X
 - Data handling (input, output, conversion, decryption, ...):
     - [tsdf](https://github.com/biomarkersParkinson/tsdf): official Python package for managing tsdf format.
-    - [ppp](https://github.com/biomarkersParkinson/ppp): loading utilities for the _ppp_ dataset.
-    - [gait](https://github.com/biomarkersParkinson/gait): pipeline and example notebooks of both the _pdathome_ dataset and the _ppp_ dataset of the gait domain.
     - [TimeStreamDB](https://github.com/biomarkersParkinson/TimeStreamDB): Max's code for data formatting.
     - [pep-download](https://github.com/biomarkersParkinson/pep-download): Peter's data acquisition scripts.
     - [parkio](https://github.com/biomarkersParkinson/parkio): input/check/output of time series.


### PR DESCRIPTION
Het is soms wat lastig de juiste repositories zoeken, en ook het overzicht van welke respositories nog in gebruik zijn is niet heel duidelijk. Daarom lijkt het mij handig om met categorieën te werken in de _organization_ space. Dan kunnen we eenvoudig de repositories bijhouden per domein.

@nienketimmermans zou je ook een korte beschrijving van de _tremor_ repos kunnen toevoegen? En misschien zie je repos die wel weg kunnen onderhand, dan kan dat ook meteen.